### PR TITLE
Install all ghga_service_chassis_lib components

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_data = True
 packages = find:
 
 install_requires =
-    ghga_service_chassis_lib[api,pubsub]==0.3.0
+    ghga_service_chassis_lib==0.3.0
     motor==2.4.0
     typer==0.3.2
 python_requires = >= 3.9


### PR DESCRIPTION
Most likely an config parsing error results from this limited install directive in the setup.cfg file.