### PR TITLE
Explicitly define the endpoint for docs and OpenAPI JSON

### DIFF
--- a/sandbox_request/api.py
+++ b/sandbox_request/api.py
@@ -22,7 +22,11 @@ from sandbox_request.config import get_config
 from sandbox_request.dao.db_connect import DBConnect
 from sandbox_request.routes.requests import request_router
 
-app = FastAPI(title="Request Service API")
+app = FastAPI(
+    title="Request Service API",
+    openapi_url="/request/docs/openapi.json",
+    docs_url="/request/docs"
+)
 configure_app(app, config=get_config())
 db_connect = DBConnect()
 


### PR DESCRIPTION
This PR changes the following endpoints:

`localhost:8000/docs` -> `localhost:8000/request/docs`
`localhost:8000/openapi.json` -> `localhost:8000/request/docs/openapi.json`