### PR TITLE
Feature/populate db indep of api (GDEV-210)

### DIFF
--- a/.devcontainer/.sandbox_request.yaml
+++ b/.devcontainer/.sandbox_request.yaml
@@ -1,4 +1,4 @@
-port: 8010
+port: 8080
 log_level: debug
 auto_reload: true
 cors_allowed_origins: ["*"]
@@ -13,11 +13,10 @@ fastapi_options:
 db_url: mongodb://db:27017
 db_name: request
 
-downloadreq_topic_name: download_request
-services: {}
+svc_metadata_url: http://mock_metadata_svc:8080
 
-rabbitmq_host: = rabbitmq
-rabbitmq_port: = 5672
+rabbitmq_host: rabbitmq
+rabbitmq_port: 5672
 
 data_requester_email: test@example.com
 data_requester_name: Data Requester

--- a/.devcontainer/dev_launcher
+++ b/.devcontainer/dev_launcher
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+COMMAND="$1" # either "rest-api" or async-api
+
 # change into the .devcontainer dir so that the config
 # yaml located there is taken into account:
 cd /workspace/.devcontainer
 
-sandbox-request
+sandbox-request "${COMMAND}"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -51,5 +51,29 @@ services:
         - 5672:5672
         - 15672:15672
 
+
+  mock_metadata_svc:
+    image: ghga/sandbox-request:dev
+    entrypoint: ["python3", "-c"]
+    command: |
+      """
+      import uvicorn
+      from fastapi import FastAPI
+
+      app = FastAPI()
+
+      @app.get('/datasets/{dataset_id}', status_code=200)
+      def get_dataset(dataset_id):
+          return {'success': True}
+
+      uvicorn.run(
+          app,
+          host='0.0.0.0',
+          port=8080
+      )
+      """
+    ports:
+      - 8081:8080
+
 volumes:
   mongodb-data:

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -3,13 +3,28 @@ port: 8080
 log_level: info
 auto_reload: false
 workers: 1
-db_url: mongodb://localhost:27017
-db_name: sandbox_requests_db
+
 cors_allowed_origins: ["http://the-other-domain-to-accept.xy"]
 cors_allow_credentials: true
 cors_allowed_methods: ["*"]
 cors_allowed_headers: ["*"]
+
+db_url: mongodb://localhost:27017
+db_name: sandbox_requests_db
+
 fastapi_options:
   root_path: "/"
   openapi_url: "/openapi.json"
   docs_url: "/docs"
+
+svc_metadata_url: http://metadata_svc:8080
+
+rabbitmq_host: rabbitmq
+rabbitmq_port: 5672
+topic_name_download_requested: download_request
+topic_name_send_notification: send_notifications
+
+data_requester_email: test@example.com
+data_requester_name: Data Requester
+data_steward_email: test@example.com
+data_steward_name: Data Steward

--- a/examples/requests.json
+++ b/examples/requests.json
@@ -1,32 +1,30 @@
-{
-  "requests": [
-    {
-      "dataset_id": "DAT:0000001",
-      "id": "REQ:0000001",
-      "purpose": "Science",
-      "status": "pending",
-      "user_id": "user_1"
-    },
-    {
-      "dataset_id": "DAT:0000002",
-      "id": "REQ:0000002",
-      "purpose": "Science",
-      "status": "pending",
-      "user_id": "user_2"
-    },
-    {
-      "dataset_id": "DAT:0000001",
-      "id": "REQ:0000003",
-      "purpose": "Science",
-      "status": "pending",
-      "user_id": "user_2"
-    },
-    {
-      "dataset_id": "DAT:0000002",
-      "id": "REQ:0000004",
-      "purpose": "Science",
-      "status": "pending",
-      "user_id": "user_3"
-    }
-  ]
-}
+[
+  {
+    "dataset_id": "DAT:0000001",
+    "id": "REQ:0000001",
+    "purpose": "Science",
+    "status": "pending",
+    "user_id": "user_1"
+  },
+  {
+    "dataset_id": "DAT:0000002",
+    "id": "REQ:0000002",
+    "purpose": "Science",
+    "status": "pending",
+    "user_id": "user_2"
+  },
+  {
+    "dataset_id": "DAT:0000001",
+    "id": "REQ:0000003",
+    "purpose": "Science",
+    "status": "pending",
+    "user_id": "user_2"
+  },
+  {
+    "dataset_id": "DAT:0000002",
+    "id": "REQ:0000004",
+    "purpose": "Science",
+    "status": "pending",
+    "user_id": "user_3"
+  }
+]

--- a/examples/requests.json
+++ b/examples/requests.json
@@ -4,27 +4,13 @@
     "id": "REQ:0000001",
     "purpose": "Science",
     "status": "pending",
-    "user_id": "user_1"
+    "user_id": "USR:0000001"
   },
   {
     "dataset_id": "DAT:0000002",
     "id": "REQ:0000002",
     "purpose": "Science",
-    "status": "pending",
-    "user_id": "user_2"
-  },
-  {
-    "dataset_id": "DAT:0000001",
-    "id": "REQ:0000003",
-    "purpose": "Science",
-    "status": "pending",
-    "user_id": "user_2"
-  },
-  {
-    "dataset_id": "DAT:0000002",
-    "id": "REQ:0000004",
-    "purpose": "Science",
-    "status": "pending",
-    "user_id": "user_3"
+    "status": "approved",
+    "user_id": "USR:0000001"
   }
 ]

--- a/sandbox_request/config.py
+++ b/sandbox_request/config.py
@@ -42,19 +42,17 @@ class Config(ApiConfigBase):
         "docs_url": "/docs",
     }
 
-    downloadreq_topic_name: str = "download_request"
-    services: Dict = {}
+    svc_metadata_url: str
 
     rabbitmq_host: str = "rabbitmq"
     rabbitmq_port: int = 5672
-
-    data_requester_email: str = None
-    data_requester_name: str = "Data Requester"
-    data_steward_email: str = None
-    data_steward_name: str = "Data Steward"
-
     topic_name_download_requested: str = "download_request"
     topic_name_send_notification: str = "send_notifications"
+
+    data_requester_email: str
+    data_requester_name: str = "Data Requester"
+    data_steward_email: str
+    data_steward_name: str = "Data Steward"
 
 
 @lru_cache

--- a/sandbox_request/core/utils.py
+++ b/sandbox_request/core/utils.py
@@ -27,7 +27,7 @@ async def check_dataset(dataset_id: str) -> Optional[Dict]:
     """Check if the given dataset ID exists in the metadata store."""
     config = get_config()
     dataset = None
-    url = f"{config.services['metadata_service']}/datasets/{dataset_id}"
+    url = f"{config.svc_metadata_url}/datasets/{dataset_id}"
     try:
         response = requests.get(url)
         if response.status_code == 200:

--- a/scripts/populate_db.py
+++ b/scripts/populate_db.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+    Populate the database with example data.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import motor.motor_asyncio
+import typer
+
+HERE = Path(__file__).parent.resolve()
+
+DEFAULT_EXAMPLES_DIR = HERE.parent.resolve() / "examples"
+DEFAULT_DB_URL = "mongodb://db:27017"
+DEFAULT_DB_NAME = "request"
+
+REQUESTS = "requests"
+COUNTER = "counter"
+COUNTER_JSON = {"_id": "requests", "value": 0}
+
+
+async def insert_one(db_url: str, db_name: str, collection_name: str, document: dict):
+    """
+    insert counter
+    """
+    client = motor.motor_asyncio.AsyncIOMotorClient(db_url)
+    collection = client[db_name][collection_name]
+    await collection.insert_one(document)
+
+
+async def delete_all_records(db_url: str, db_name: str, collection_name: str):
+    """
+    delete requests
+    """
+    client = motor.motor_asyncio.AsyncIOMotorClient(db_url)
+    collection = client[db_name][collection_name]
+    await collection.delete_many({})
+
+
+async def update_counter(db_url: str, db_name: str, counter: str, collection_name: str):
+    """
+    This method generates the sequence id for the MongoDB document
+    """
+    client = motor.motor_asyncio.AsyncIOMotorClient(db_url)
+    collection = client[db_name][counter]
+    collection.update_one({"_id": collection_name}, {"$inc": {"value": 1}})  # type: ignore
+
+
+async def get_collection(db_url: str, db_name: str, collection_name: str):
+    """
+    get all requests
+    """
+    client = motor.motor_asyncio.AsyncIOMotorClient(db_url)
+    collection = client[db_name][collection_name]
+    result = collection.find()
+    return await result.to_list(None)
+
+
+async def reset_and_populate_db(
+    db_url: str, db_name: str, example_dir: Path = DEFAULT_EXAMPLES_DIR
+):
+    """
+    Deletes all DB entries and populates the
+    database with examples
+    """
+
+    with open(example_dir / "requests.json") as requests_file:
+        requests = json.load(requests_file)
+
+    # reset/populate the COUNTER collection:
+    await delete_all_records(db_url, db_name, COUNTER)
+    await insert_one(db_url, db_name, COUNTER, COUNTER_JSON)
+
+    # reset/populate the COUNTER collection:
+    await delete_all_records(db_url, db_name, REQUESTS)
+    for request in requests:
+        await insert_one(db_url, db_name, REQUESTS, request)
+        await update_counter(db_url, db_name, COUNTER, REQUESTS)
+    typer.echo("- added Counter:")
+    typer.echo(await get_collection(db_url, db_name, COUNTER))
+    typer.echo("- added Requests:")
+    typer.echo(await get_collection(db_url, db_name, REQUESTS))
+
+
+def main(
+    db_url: str = DEFAULT_DB_URL,
+    db_name: str = DEFAULT_DB_NAME,
+    example_dir: Path = DEFAULT_EXAMPLES_DIR,
+):
+    """Main entrypoint. Handles the event loop."""
+
+    typer.echo("This will populate the database with examples.")
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(reset_and_populate_db(db_url, db_name, example_dir))
+
+    typer.echo("Done.")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/populate_db_via_api.py
+++ b/scripts/populate_db_via_api.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Populates the database with example data for the request service"""
+"""Populates the database with example data via the API"""
 
 import os
 import json
@@ -38,7 +38,7 @@ def populate_record(
             records = json.load(records_file)
         route = f"{base_url}/{record_type}"
         print(route)
-        for record in records[record_type]:
+        for record in records:
             print(record)
             response = requests.post(route, json=record)
             if exit_on_error:


### PR DESCRIPTION
Brought back the population script that directly talks to the database.

Suggestion for Squash and Merge:

Title:
```
re-introduced DB population script independent of API
```

Description:
```
Re-introduced DB population script independent of API.
This is important to set fixed IDs and statuses for the request examples.
Those fields cannot be set with a POST to the API.
```